### PR TITLE
Info Box Update for day 518

### DIFF
--- a/day518.htm
+++ b/day518.htm
@@ -149,11 +149,11 @@
       This works by sending GET requests to each targeted website. It’s like opening each website in a random sequence on your PC and re-requesting the data over and over, although the data is not saved or cached, Due to the way it work, It should be fair to say that your Internet service Provider (ISP) won’t be any more bothered about this than they would you browsing the internet, but its always best to stay safe when it comes to security.                                                                                                                                                                                                                                                           
   <hr style=" margin-top: 3px; margin-bottom: 3px;">
       <p><span style="font-size:14px;"><u></u><strong>Todays message from the IT Army of Ukraine: </strong></span>&nbsp;<br>
-    &nbsp; &nbsp; &nbsp; Russian internet without interruptions in occupied territories?<br>
-    &nbsp; &nbsp; &nbsp; Not on our watch. The provider "Luganet" is still reeling from<br>
-    &nbsp; &nbsp; &nbsp; our onslaught and a long way from recovery. <br>
-    &nbsp; &nbsp; &nbsp; And while "Luganet" might suggest otherwise, let's not <br>
-    &nbsp; &nbsp; &nbsp; forget: Lugansk was, is, and will always be Ukrainian.<span style="font-size:14px;"><u></u><strong><br>
+    &nbsp; &nbsp; &nbsp; In the Ruzzia, data breaches last year surpassed the number<br>
+    &nbsp; &nbsp; &nbsp; of citizens - 188.7 million against 146.4 million.<br>
+    &nbsp; &nbsp; &nbsp; Wondering who they've chosen to blame? Of course,<br>
+    &nbsp; &nbsp; &nbsp; 'those notorious Ukrainian hackers'. So, our very own <br>
+    &nbsp; &nbsp; &nbsp; IT Army of Ukraine got a 'whisper of praise'. We don't mind.<span style="font-size:14px;"><u></u><strong><br>
       Additional message for newly added targets:&nbsp;&nbsp;<br></strong>
     &nbsp; &nbsp; &nbsp; To keep up with targets we're going to use the db1000n targets<br>
     &nbsp; &nbsp; &nbsp; direct from their GitHub repository.<br>


### PR DESCRIPTION
Simply run this for as long as you can to help flood Russia in the most legal, yet effective way possible  New targets imported from db1000n:
To keep up with targets we're going to use the db1000n targets direct from their GitHub repository.  These updates will be daily, so if the db1000n changes, it will probably take a few hours longer for the change to make it here. Message posted by the IT Army of Ukraine:
In the Ruzzia, data breaches last year surpassed the number of citizens - 188.7 million against 146.4 million. Wondering who they've chosen to blame? Of course, 'those notorious Ukrainian hackers'. So, our very own IT Army of Ukraine got a 'whisper of praise'. We don't mind.

/ *** / 
Просто запускайте це стільки, скільки зможете, щоб допомогти наповнити Росію найбільш законним, але ефективним способом  Нові цілі, імпортовані з db1000n:
Щоб не відставати від цілей, ми збираємося використовувати цілі db1000n безпосередньо з їхнього сховища GitHub. Ці оновлення відбуватимуться щодня, тож якщо db1000n зміниться, ймовірно, знадобиться кілька годин більше, перш ніж зміни з’являться тут. Повідомлення оприлюднило IT Army of Ukraine:
Щоб не відставати від цілей, ми збираємося використовувати цілі db1000n безпосередньо з їхнього сховища GitHub. Ці оновлення відбуватимуться щодня, тож якщо db1000n зміниться, ймовірно, знадобиться кілька годин більше, перш ніж зміни з’являться тут. Повідомлення оприлюднило IT Army of Ukraine: На росії випадків втечі даних набралося більше, ніж громадян за останній рік - 188,7 млн проти 146,4 млн. Цікаво, кого обрали винуватцями? Звісно, 'відомі українські хакери'. Тож і про нашу IT Army of Ukraine згадали "незлим тихим словом". Ми тільки "за".