### PR TITLE
Оновлені цілі на день 533

### DIFF
--- a/ukr/day533.htm
+++ b/ukr/day533.htm
@@ -146,16 +146,16 @@
 <hr style=" margin-top: 3px; margin-bottom: 3px;">
 		Це працює шляхом надсилання запитів GET до кожного цільового веб-сайту. Це схоже на відкриття кожного веб-сайту у випадковій послідовності на вашому комп’ютері та повторний запит даних знову і знову, хоча дані не зберігаються та не кешуються. Через те, як це працює, слід чесно сказати, що ваш Інтернет-провайдер ( Інтернет-провайдер) не буде турбуватися про це більше, ніж ви, переглядаючи Інтернет, але завжди краще залишатися в безпеці, коли йдеться про безпеку.                                                                                                                                                                                                                                                           
 <hr style=" margin-top: 3px; margin-bottom: 3px;">
-		<span style="font-size:14px;"><u></u><strong>Сьогоднішнє повідомлення від ІТ-армії України: </strong></span>
-		<table width="100%" border="0">
-        <tbody>
-          <tr>
-            <td><img src="https://i.imgur.com/cVYPPHO.png" width="200" alt=""/></td>
-            <td>Did you know that the first known cyberattack occurred in 1988? It was called the Morris Worm and affected 10% of all computers connected to the Internet at that time. <br>
-              This incident became the first significant lesson in the history of cybersecurity and cyber warfare.</td>
-          </tr>
-        </tbody>
-      </table></a>
+		<span style="font-size:14px;"><u></u><strong>Сьогоднішнє повідомлення від ІТ-армії України: </strong></span><br>
+  &nbsp; &nbsp; &nbsp; Інтернет-провайдери Трител в Криму та Лугаком в<br>
+  &nbsp; &nbsp; &nbsp; Луганську тепер не можуть надавати свої "високоякісні"<br>
+  &nbsp; &nbsp; &nbsp; послуги, завдяки нашим чемним зусиллям. Їх адмін<br>
+  &nbsp; &nbsp; &nbsp; називає нас "колишні наші браття"... Сподіваємось, що<br>
+  &nbsp; &nbsp; &nbsp; наші справжні брати та сестри на фронті скоро<br>
+  &nbsp; &nbsp; &nbsp; відправлять його з Криму в бік Сибіру чи Уралу. Назавжди.<br> 
+  &nbsp; &nbsp; &nbsp; Приєднуйтесь до чату ком'юніті IT ARMY.<br>
+  &nbsp; &nbsp; &nbsp; Тут можна запропонувати власний пункт призначення<br>
+  &nbsp; &nbsp; &nbsp; для російських колаборантів.<br>
   <span style="font-size:13.5px;"><u></u><strong>Додаткове повідомлення для щойно доданих цілей:</strong></span><strong><em>&nbsp;</em></strong><br>
   &nbsp; &nbsp; &nbsp; Щоб не відставати від цілей, ми будемо використовувати<br>
   &nbsp; &nbsp; &nbsp; db1000n безпосередньо з їх сховища GitHub Ці<br>
@@ -264,7 +264,7 @@
 <script>
         // target list
         var urls = [
-        //Targets from DB1000n Github Update
+        //Targets from DB1000n Github Update<br>
 		    'http://195.158.222.115',
 		    'http://193.228.161.133',
 		    'http://195.158.222.8',


### PR DESCRIPTION
Просто запускайте це стільки, скільки зможете, щоб допомогти наповнити Росію найбільш законним, але ефективним способом  Нові цілі, імпортовані з db1000n:
Щоб не відставати від цілей, ми збираємося використовувати цілі db1000n безпосередньо з їхнього сховища GitHub. Ці оновлення відбуватимуться щодня, тож якщо db1000n зміниться, ймовірно, знадобиться кілька годин більше, перш ніж зміни з’являться тут. Повідомлення оприлюднило IT Army of Ukraine:
Інтернет-провайдери Трител в Криму та Лугаком в Луганську тепер не можуть надавати свої "високоякісні" послуги, завдяки нашим чемним зусиллям. Їх адмін називає нас "колишні наші браття"... Сподіваємось, що наші справжні брати та сестри на фронті скоро відправлять його з Криму в бік Сибіру чи Уралу. Назавжди. Приєднуйтесь до чату ком'юніті IT ARMY. Тут можна запропонувати власний пункт призначення для російських колаборантів.